### PR TITLE
[Fix] ChatController - isEmergency 동적 설정

### DIFF
--- a/src/main/java/com/example/airchat/ChatController.java
+++ b/src/main/java/com/example/airchat/ChatController.java
@@ -1,5 +1,6 @@
 package com.example.airchat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -8,15 +9,34 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Controller
-@CrossOrigin(origins = "http://localhost:3000")
 public class ChatController {
 
-    // 클라이언트가 "/pub/chat"로 메시지를 보낼 때 호출됨
+    private final ObjectMapper objectMapper = new ObjectMapper(); // ObjectMapper를 사용하여 JSON을 객체로 변환
+
     @MessageMapping("/chat")
-    @SendTo("/sub/chat")  // 모든 구독자에게 메시지를 전달
-    public String handleChatMessage(String message) {
-        System.out.println("Received message: " + message);  // 로그 추가
-        return message;  // 받은 메시지를 그대로 반환 (구독자에게 전송)
+    @SendTo("/sub/chat")
+    public Map<String, Object> handleChatMessage(String message) {
+        try {
+            // 받은 메시지를 JSON 객체로 변환
+            Map<String, Object> messageMap = objectMapper.readValue(message, Map.class);
+
+            // "긴급" 또는 "SOS" 단어가 포함되어 있는지 확인
+            String content = (String) messageMap.get("content");
+            boolean isEmergency = content.contains("긴급") || content.contains("SOS");
+
+            // isEmergency만 수정
+            messageMap.put("isEmergency", isEmergency);
+
+            // 수정된 메시지 반환
+            System.out.println("Response message: " + messageMap);
+            return messageMap;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 }


### PR DESCRIPTION
- [x] 메세지 내용에 '긴급', 'SOS'가 있다면, isEmergency 값을 true로 변환해 클라이언트에 반환

- 클라이언트 -> 서버
![image](https://github.com/user-attachments/assets/e5d46de1-0c1b-4063-a101-26be3351e51c)

- 서버 -> 클라이언트 ('긴급' 단어가 있으므로, isEmergency 값을 true로)
![image](https://github.com/user-attachments/assets/df7bb6cf-18ad-4851-8d53-39d38cf24337)

